### PR TITLE
Disable unused features in tonic and prost

### DIFF
--- a/tonic-richer-error/Cargo.toml
+++ b/tonic-richer-error/Cargo.toml
@@ -14,9 +14,10 @@ repository = "https://github.com/flemosr/tonic-richer-error"
 version = "0.3.1"
 
 [dependencies]
-prost = "0.11"
+prost = { version = "0.11", default-features = false }
 prost-types = "0.11"
-tonic = "0.8"
+tonic = { version = "0.8", default-features = false, features = ["codegen", "prost"] }
+
 
 [build-dependencies]
 prost-build = "0.11"


### PR DESCRIPTION
This change allows this crate to be compiled for WASM targets.